### PR TITLE
runit.h: change RUNIT define.

### DIFF
--- a/src/runit.h
+++ b/src/runit.h
@@ -1,4 +1,4 @@
-#define RUNIT "/sbin/runit"
+#define RUNIT "/usr/bin/runit"
 #define STOPIT "/etc/runit/stopit"
 #define REBOOT "/etc/runit/reboot"
 #define CTRLALTDEL "/etc/runit/ctrlaltdel"


### PR DESCRIPTION
Currently, the runit template in void-packages `vsed`s this to `/usr/bin/runit`.

@sgn pointed out that leaving it as `/sbin/runit` is better because it allows for distros that haven't gone through usrmerge to still use this project. On the other hand, is there a chance that `/sbin` on someone's system doesn't point to `/usr/bin`, making this change still necessary, either here or in the template?

We could make it a proper build time configuration, as well.