### PR TITLE
completions: add SVDIR support for zsh

### DIFF
--- a/completions/sv.zsh
+++ b/completions/sv.zsh
@@ -35,7 +35,13 @@ cmds)
         check
     ret=0;;
 args)
-    services=( /var/service/*(-/N:t) )
+    if [[ $BUFFER == "sudo "*
+        || $BUFFER == "doas "*
+        || $BUFFER == "su "*-c* ]] then
+        services=( /var/service/*(-/N:t) )
+    else
+        services=( ${SVDIR:-/var/service}/*(-/N:t) )
+    fi
     (( $#services )) && _values services $services && ret=0
     [[ $words[CURRENT] = */* ]] && _directories && ret=0
     ;;


### PR DESCRIPTION
Moved from void-linux/void-packages#28790

Allows sv's completion to complete other service directories, e.g. for per-user services.
If the $SVDIR environment variable is set and sv isn't used with sudo, the completion is changed to complete services from $SVDIR. Otherwise behaviour is unchanged.

I currently have only implemented the change for zsh. In bash, the sudo completion modifies variables so that the completion of the following command doesn't "see" the sudo in the beginning. I'm still looking for ways to detect sudo in bash.