### PR TITLE
wait.h: fix wait_exitcode macro.

### DIFF
--- a/src/wait.h
+++ b/src/wait.h
@@ -9,7 +9,7 @@ extern int wait_stop();
 extern int wait_stopnohang();
 
 #define wait_crashed(w) ((w) & 127)
-#define wait_exitcode(w) ((w) >> 8)
+#define wait_exitcode(w) ((w) & 255)
 #define wait_stopsig(w) ((w) >> 8)
 #define wait_stopped(w) (((w) & 127) == 127)
 


### PR DESCRIPTION
Apparently a mistake from copy pasting. This was hiding the actual exit
codes (usually became only 0), so much of the logic around detecting
return codes from children was wrong. This includes runit and stage 2:
runsvdir exiting due to a signal or crash should have prompted runit to
try and start stage 2 anew; instead, it was just proceeding with the
poweroff sequence.