### PR TITLE
sv.c: Avoid masking service status with log status

### DIFF
--- a/src/sv.c
+++ b/src/sv.c
@@ -152,7 +152,7 @@ unsigned int svstatus_print(char *m) {
   return(pid ? 1 : 2);
 }
 int status(char *unused) {
-  int rc;
+  int rc, log_rc;
 
   rc =svstatus_get();
   switch(rc) { case -1: if (lsb) done(4); case 0: return(0); }
@@ -167,10 +167,11 @@ int status(char *unused) {
   }
   else {
     outs("; ");
-    if (svstatus_get()) { rc =svstatus_print("log"); outs("\n"); }
+    if (svstatus_get()) { log_rc =svstatus_print("log"); outs("\n"); }
   }
   islog =0;
   flush("");
+  if (rc == 0 && log_rc != 0) { rc =log_rc; }
   if (lsb) switch(rc) { case 1: done(0); case 2: done(3); case 0: done(4); }
   return(rc);
 }


### PR DESCRIPTION
Use log status only if service is okay but log isn't. In all other
cases, use service status.

Fixes #20.

<details>
<summary>Before</summary>

```
❯ xbps-query runit | ag 'repo|pkgver'
pkgver: runit-2.1.2_11
repository: https://repo-us.voidlinux.org/current
❯ fd -t f . /etc/sv/issue-20 -X head    
==> /etc/sv/issue-20/run <==
#!/bin/sh
echo 'Sleeping for 60 seconds.'
exec /usr/bin/sleep 60

==> /etc/sv/issue-20/log/run <==
#!/bin/sh
exec /usr/bin/false
❯ ls -l /etc/init.d/issue-20 
lrwxrwxrwx 1 root root 11 Aug  5 18:09 /etc/init.d/issue-20 -> /usr/bin/sv
❯ sudo /etc/init.d/issue-20 status
run: issue-20: (pid 8220) 44s; down: log: 1s, normally up, want up
❯ echo $?  # expecting 0
3
```
</details>

<details>
<summary>After</summary>

```
❯ xbps-query runit | ag 'repo|pkgver'
pkgver: runit-2.1.2_12
repository: /tmp/xdowngrade-2022-08-05.p555tSVo
❯ sudo /etc/init.d/issue-20 status
run: issue-20: (pid 21075) 30s; down: log: 0s, normally up, want up
❯ echo $?
0
```
</details>
