### PR TITLE
svlogd.c: fix clause guard warning in GCC

### DIFF
--- a/src/svlogd.c
+++ b/src/svlogd.c
@@ -392,11 +392,11 @@ unsigned int ip4_scan(const char *s,char ip[4])
  
   len = 0;
   i = scan_ulong(s,&u); if (!i) return 0; ip[0] = u; s += i; len += i;
-  if (*s != '.') return 0; ++s; ++len;
+  if (*s != '.') { return 0; } ++s; ++len;
   i = scan_ulong(s,&u); if (!i) return 0; ip[1] = u; s += i; len += i;
-  if (*s != '.') return 0; ++s; ++len;
+  if (*s != '.') { return 0; } ++s; ++len;
   i = scan_ulong(s,&u); if (!i) return 0; ip[2] = u; s += i; len += i;
-  if (*s != '.') return 0; ++s; ++len;
+  if (*s != '.') { return 0; } ++s; ++len;
   i = scan_ulong(s,&u); if (!i) return 0; ip[3] = u; s += i; len += i;
   return len;
 }


### PR DESCRIPTION
On compilation, GCC emits `'if' clause does not guard` warning (`-Wmisleading-indentation`). Wrapping the return value would prevent this indent warning. 