### PR TITLE
Fix clang warnings

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -12,8 +12,7 @@ static aligned realspace[SPACE / ALIGNMENT];
 #define space ((char *) realspace)
 static unsigned int avail = SPACE; /* multiple of ALIGNMENT; 0<=avail<=SPACE */
 
-/*@null@*//*@out@*/char *alloc(n)
-unsigned int n;
+/*@null@*//*@out@*/char *alloc(unsigned int n)
 {
   char *x;
   n = ALIGNMENT + n - (n & (ALIGNMENT - 1)); /* XXX: could overflow */
@@ -23,8 +22,7 @@ unsigned int n;
   return x;
 }
 
-void alloc_free(x)
-char *x;
+void alloc_free(char *x)
 {
   if (x >= space)
     if (x < space + SPACE)

--- a/src/alloc.h
+++ b/src/alloc.h
@@ -3,8 +3,8 @@
 #ifndef ALLOC_H
 #define ALLOC_H
 
-extern /*@null@*//*@out@*/char *alloc();
-extern void alloc_free();
-extern int alloc_re();
+extern /*@null@*//*@out@*/char *alloc(unsigned int n);
+extern void alloc_free(char *x);
+extern int alloc_re(char **x, unsigned int m, unsigned int n);
 
 #endif

--- a/src/alloc_re.c
+++ b/src/alloc_re.c
@@ -3,10 +3,7 @@
 #include "alloc.h"
 #include "byte.h"
 
-int alloc_re(x,m,n)
-char **x;
-unsigned int m;
-unsigned int n;
+int alloc_re(char **x, unsigned int m, unsigned int n)
 {
   char *y;
  

--- a/src/byte.h
+++ b/src/byte.h
@@ -3,12 +3,11 @@
 #ifndef BYTE_H
 #define BYTE_H
 
-extern unsigned int byte_chr();
-extern unsigned int byte_rchr();
-extern void byte_copy();
-extern void byte_copyr();
-extern int byte_diff();
-extern void byte_zero();
+extern unsigned int byte_chr(char *s, register unsigned int n, int c);
+extern unsigned int byte_rchr(char *s, register unsigned int n, int c);
+extern void byte_copy(register char *to, register unsigned int n, register char *from);
+extern void byte_copyr(register char *to, register unsigned int n, register char *from);
+extern int byte_diff(register char *s, register unsigned int n, register char *t);
 
 #define byte_equal(s,n,t) (!byte_diff((s),(n),(t)))
 

--- a/src/byte_chr.c
+++ b/src/byte_chr.c
@@ -2,10 +2,7 @@
 
 #include "byte.h"
 
-unsigned int byte_chr(s,n,c)
-char *s;
-register unsigned int n;
-int c;
+unsigned int byte_chr(char *s, register unsigned int n, int c)
 {
   register char ch;
   register char *t;

--- a/src/byte_copy.c
+++ b/src/byte_copy.c
@@ -2,10 +2,7 @@
 
 #include "byte.h"
 
-void byte_copy(to,n,from)
-register char *to;
-register unsigned int n;
-register char *from;
+void byte_copy(register char *to, register unsigned int n, register char *from)
 {
   for (;;) {
     if (!n) return; *to++ = *from++; --n;

--- a/src/byte_cr.c
+++ b/src/byte_cr.c
@@ -2,10 +2,7 @@
 
 #include "byte.h"
 
-void byte_copyr(to,n,from)
-register char *to;
-register unsigned int n;
-register char *from;
+void byte_copyr(register char *to, register unsigned int n, register char *from)
 {
   to += n;
   from += n;

--- a/src/byte_diff.c
+++ b/src/byte_diff.c
@@ -2,10 +2,7 @@
 
 #include "byte.h"
 
-int byte_diff(s,n,t)
-register char *s;
-register unsigned int n;
-register char *t;
+int byte_diff(register char *s, register unsigned int n, register char *t)
 {
   for (;;) {
     if (!n) return 0; if (*s != *t) break; ++s; ++t; --n;

--- a/src/byte_rchr.c
+++ b/src/byte_rchr.c
@@ -2,10 +2,7 @@
 
 #include "byte.h"
 
-unsigned int byte_rchr(s,n,c)
-char *s;
-register unsigned int n;
-int c;
+unsigned int byte_rchr(char *s, register unsigned int n, int c)
 {
   register char ch;
   register char *t;

--- a/src/wait.h
+++ b/src/wait.h
@@ -3,10 +3,8 @@
 #ifndef WAIT_H
 #define WAIT_H
 
-extern int wait_pid();
-extern int wait_nohang();
-extern int wait_stop();
-extern int wait_stopnohang();
+extern int wait_pid(int *wstat, int pid);
+extern int wait_nohang(int *wstat);
 
 #define wait_crashed(w) ((w) & 127)
 #define wait_exitcode(w) ((w) >> 8)

--- a/src/wait_nohang.c
+++ b/src/wait_nohang.c
@@ -4,7 +4,7 @@
 #include <sys/wait.h>
 #include "haswaitp.h"
 
-int wait_nohang(wstat) int *wstat;
+int wait_nohang(int *wstat)
 {
 #ifdef HASWAITPID
   return waitpid(-1,wstat,WNOHANG);

--- a/src/wait_pid.c
+++ b/src/wait_pid.c
@@ -7,7 +7,7 @@
 
 #ifdef HASWAITPID
 
-int wait_pid(wstat,pid) int *wstat; int pid;
+int wait_pid(int *wstat, int pid)
 {
   int r;
 
@@ -24,7 +24,7 @@ int wait_pid(wstat,pid) int *wstat; int pid;
 static int oldpid = 0;
 static int oldwstat; /* defined if(oldpid) */
 
-int wait_pid(wstat,pid) int *wstat; int pid;
+int wait_pid(int *wstat, int pid)
 {
   int r;
 


### PR DESCRIPTION
When building with clang, we get a different set of warnings than with gcc. This is my attempt at fixing them.

- [X] Many instances of trivial `-Wdeprecated-non-prototype`, exposing previously hidden warnings:
  - [ ] `-Wincompatible-pointer-types-discards-qualifiers` for byte.h
  - [ ] `-Wincompatible-pointer-types` for alloc.h
- buffer.h - Since I'm currently in an attempt to remove buffer.h, I'm not taking care of it here.
    - glorious `-Wempty-body` in `buffer_put.c` https://github.com/void-linux/runit/blob/2b8000f1ebd07fd68ee0e3c32737d97bcd1687fb/src/buffer_put.c#L18
        It's interesting to see [how much has that line spread in the wild.](https://github.com/search?q=%22%2F*+luser%27s+fault+*%2F%22+language%3AC+&type=code)
    - gnarly `-Wdeprecated-non-prototype` in `buffer_{get,put}.c` https://github.com/void-linux/runit/blob/2b8000f1ebd07fd68ee0e3c32737d97bcd1687fb/src/buffer_put.c#L13


I also found and removed unused functions that had no implementations.