### PR TITLE
[svlogd] prevent deletion of the processing file

### DIFF
--- a/src/svlogd.c
+++ b/src/svlogd.c
@@ -235,6 +235,10 @@ void rmoldest(struct logdir *ld) {
         if (unlink(f->d_name) == -1)
           warn2("unable to unlink processor leftover", f->d_name);
       }
+      else if (!str_diff(f->d_name, ld->fnsave)) {
+          if (verbose)
+              strerr_warn4(INFO, "preserve: ", ld->name, "/", f->d_name);
+      }
       else {
         ++n;
         if (str_diff(f->d_name, oldest) < 0) byte_copy(oldest, 27, f->d_name);


### PR DESCRIPTION
svlogd expects time to be correct, but sometimes this is not the case. If time information is inaccurate, it is possible for svlogd to delete the file it is about to process. When this happens, svlogd will enter an infinite busy loop trying to process a file that no longer exists. This patch prevents that case from happening by excluding processing file from consideration when removing old log files.